### PR TITLE
Point2d float to int

### DIFF
--- a/PantMerchant.xml
+++ b/PantMerchant.xml
@@ -197,6 +197,15 @@
             </summary>
             <returns>[X,Y]</returns>
         </member>
+        <member name="M:PantMerchant.Point2D.GetRelativePosition(PantMerchant.Point2D)">
+            <summary>
+            Returns the displacement of the provided Point2D from the 
+            current one. How many X units and how many Y units to travel 
+            to go from this one to the provided one.
+            </summary>
+            <param name="p">Point2D to compare with this one.</param>
+            <returns>Point2D representing the displacement between the provided one and the current one.</returns>
+        </member>
         <member name="M:PantMerchant.Point2D.op_Equality(PantMerchant.Point2D,PantMerchant.Point2D)">
             <summary>
             Determines if the coordinates are equal. Returns true if X and Y components are respectively equal.
@@ -225,6 +234,63 @@
             Gets hash code based on the sum of the X and Y coordinates.
             </summary>
             <returns>Hash code based on sum of components</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Addition(PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Performs vector addition on two Point2Ds
+            </summary>
+            <param name="p1">Point2D to sum</param>
+            <param name="p2">Point2D to sum</param>
+            <returns>Returns the vector sum of p1 and p2</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Subtraction(PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Performs vector subtraction on two Point2Ds
+            </summary>
+            <param name="p1">Point2D to perform subtraction on</param>
+            <param name="p2">Point2D to subtract from p1</param>
+            <returns>Returns the vector sum of p1 and -(p2)</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Multiply(PantMerchant.Point2D,System.Double)">
+            <summary>
+            Performs scalar multiplication on a vector p with d
+            </summary>
+            <param name="p">The vector to multiply</param>
+            <param name="d">The scalar to multiply the p by</param>
+            <returns>The product of p and d</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Division(PantMerchant.Point2D,System.Double)">
+            <summary>
+            Performs scalar division on a vector p with i, 
+            rounding the components of p to the nearest integer.
+            Equivalent to multiplying p by the reciprocal of i
+            </summary>
+            <param name="p">The vector to perform the division on</param>
+            <param name="d">The scalar to divide p by</param>
+            <returns>The quotient of p by d</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Implicit(PantMerchant.Point2D)~SwinGameSDK.Point2D">
+            <summary>
+            Performs implicit conversion between PantMerchant's Point2D and 
+            SwinGame's in-built Point2D class.
+            </summary>
+            <param name="p">PantMerchant Point2D to convert</param>
+            <returns>SwinGame Point2D</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Implicit(SwinGameSDK.Point2D)~PantMerchant.Point2D">
+            <summary>
+            Performs implicit conversion between PantMerchant's Point2D and 
+            SwinGame's in-built Point2D class.
+            </summary>
+            <param name="p">SwinGame Point2D to convert</param>
+            <returns>PantMerchant Point2D</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.Round(System.Double)">
+            <summary>
+            Rounds a double to the nearest int
+            </summary>
+            <param name="d"></param>
+            <returns></returns>
         </member>
         <member name="T:PantMerchant.IClickable">
             <summary>

--- a/PantMerchant.xml
+++ b/PantMerchant.xml
@@ -191,6 +191,34 @@
             </summary>
             <returns>Boolean indicating whether the user has requested to close the program.</returns>
         </member>
+        <member name="T:PantMerchant.Point2D">
+            <summary>
+            Basic vector class. Based on SwinGame's Point2D 
+            class, but with some helpful overloads
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Point2D.X">
+            <summary>
+            Vector components
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Point2D.Y">
+            <summary>
+            Vector components
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Point2D.#ctor">
+            <summary>
+            Initialises a new Point2D instance with X and Y set to zero.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Point2D.#ctor(System.Int32,System.Int32)">
+            <summary>
+            Initialises a new Poin2D instance with X and Y set.
+            </summary>
+            <param name="X">Value to set X component to</param>
+            <param name="Y">Value to set Y component to</param>
+        </member>
         <member name="M:PantMerchant.Point2D.ToString">
             <summary>
             Enables printing the class.

--- a/src/Point2D.cs
+++ b/src/Point2D.cs
@@ -25,6 +25,13 @@ namespace PantMerchant
             return "[" + X + "," + Y + "]";
         }
 
+        /// <summary>
+        /// Returns the displacement of the provided Point2D from the 
+        /// current one. How many X units and how many Y units to travel 
+        /// to go from this one to the provided one.
+        /// </summary>
+        /// <param name="p">Point2D to compare with this one.</param>
+        /// <returns>Point2D representing the displacement between the provided one and the current one.</returns>
         public Point2D GetRelativePosition(Point2D p){
             return p - this;
         }
@@ -72,40 +79,66 @@ namespace PantMerchant
             return sum.GetHashCode();
         }
 
+        /// <summary>
+        /// Performs vector addition on two Point2Ds
+        /// </summary>
+        /// <param name="p1">Point2D to sum</param>
+        /// <param name="p2">Point2D to sum</param>
+        /// <returns>Returns the vector sum of p1 and p2</returns>
         public static Point2D operator +(Point2D p1, Point2D p2) {
 			return new Point2D(p1.X + p2.X, p1.Y + p2.Y);
 		}
 
+        /// <summary>
+        /// Performs vector subtraction on two Point2Ds
+        /// </summary>
+        /// <param name="p1">Point2D to perform subtraction on</param>
+        /// <param name="p2">Point2D to subtract from p1</param>
+        /// <returns>Returns the vector sum of p1 and -(p2)</returns>
 		public static Point2D operator -(Point2D p1, Point2D p2) {
 			return new Point2D(p1.X - p2.X, p1.Y - p2.Y);
 		}
 
-		public static Point2D operator *(Point2D p, float i) {
-			return new Point2D(Point2D.Round(p.X *i), Point2D.Round(p.Y*i));
+        /// <summary>
+        /// Performs scalar multiplication on a vector p with d
+        /// </summary>
+        /// <param name="p">The vector to multiply</param>
+        /// <param name="d">The scalar to multiply the p by</param>
+        /// <returns>The product of p and d</returns>
+		public static Point2D operator *(Point2D p, double d) {
+			return new Point2D(Point2D.Round(p.X *d), Point2D.Round(p.Y*d));
 		}
 
-		public static Point2D operator /(Point2D p, int i) {
-			return new Point2D(p.X / i, p.Y / i);
-		}
-
+        /// <summary>
+        /// Performs scalar division on a vector p with i, 
+        /// rounding the components of p to the nearest integer.
+        /// Equivalent to multiplying p by the reciprocal of i
+        /// </summary>
+        /// <param name="p">The vector to perform the division on</param>
+        /// <param name="d">The scalar to divide p by</param>
+        /// <returns>The quotient of p by d</returns>
 		public static Point2D operator /(Point2D p, double d) {
-			return new Point2D((Point2D.Round(p.X / d)), (Point2D.Round(p.Y / d)));
+            return p * (1 / d);
 		}
-
+        
+        /// <summary>
+        /// Performs implicit conversion between PantMerchant's Point2D and 
+        /// SwinGame's in-built Point2D class.
+        /// </summary>
+        /// <param name="p">PantMerchant Point2D to convert</param>
+        /// <returns>SwinGame Point2D</returns>
 		public static implicit operator SwinGameSDK.Point2D(PantMerchant.Point2D p){
-		// Automatically convert between my Point2D and SwinGame's Point2D
-			SwinGameSDK.Point2D result = new SwinGameSDK.Point2D ();
-			result.X = p.X;
-			result.Y = p.Y;
-			return result;
+			return new SwinGameSDK.Point2D() { X = p.X, Y = p.Y };
 		}
 
+        /// <summary>
+        /// Performs implicit conversion between PantMerchant's Point2D and 
+        /// SwinGame's in-built Point2D class.
+        /// </summary>
+        /// <param name="p">SwinGame Point2D to convert</param>
+        /// <returns>PantMerchant Point2D</returns>
 		public static implicit operator PantMerchant.Point2D(SwinGameSDK.Point2D p){
-            // Automatically convert between my Point2D and SwinGame's Point2D
-            PantMerchant.Point2D result = new PantMerchant.Point2D ();
-			result.X = Point2D.Round(p.X);
-			result.Y = Point2D.Round(p.Y);
-			return result;
+			return new PantMerchant.Point2D(Point2D.Round(p.X), Point2D.Round(p.Y));
 		}
 
         /// <summary>

--- a/src/Point2D.cs
+++ b/src/Point2D.cs
@@ -5,12 +5,27 @@ using static SwinGameSDK.SwinGame;
 
 namespace PantMerchant
 {
+    /// <summary>
+    /// Basic vector class. Based on SwinGame's Point2D 
+    /// class, but with some helpful overloads
+    /// </summary>
 	public class Point2D {
 
+        /// <summary>
+        /// Vector components
+        /// </summary>
 		public int X, Y;
 
+        /// <summary>
+        /// Initialises a new Point2D instance with X and Y set to zero.
+        /// </summary>
 		public Point2D() : this(0, 0) {}
 
+        /// <summary>
+        /// Initialises a new Poin2D instance with X and Y set.
+        /// </summary>
+        /// <param name="X">Value to set X component to</param>
+        /// <param name="Y">Value to set Y component to</param>
 		public Point2D(int X, int Y) {
 			this.X = X;
 			this.Y = Y;

--- a/src/Point2D.cs
+++ b/src/Point2D.cs
@@ -7,11 +7,11 @@ namespace PantMerchant
 {
 	public class Point2D {
 
-		public float X, Y;
+		public int X, Y;
 
 		public Point2D() : this(0, 0) {}
 
-		public Point2D(float X, float Y) {
+		public Point2D(int X, int Y) {
 			this.X = X;
 			this.Y = Y;
 		}
@@ -81,7 +81,7 @@ namespace PantMerchant
 		}
 
 		public static Point2D operator *(Point2D p, float i) {
-			return new Point2D(p.X *i, p.Y*i);
+			return new Point2D(Point2D.Round(p.X *i), Point2D.Round(p.Y*i));
 		}
 
 		public static Point2D operator /(Point2D p, int i) {
@@ -89,7 +89,7 @@ namespace PantMerchant
 		}
 
 		public static Point2D operator /(Point2D p, double d) {
-			return new Point2D((float)((double)p.X / d), (float)((double)p.Y / d));
+			return new Point2D((Point2D.Round(p.X / d)), (Point2D.Round(p.Y / d)));
 		}
 
 		public static implicit operator SwinGameSDK.Point2D(PantMerchant.Point2D p){
@@ -103,10 +103,24 @@ namespace PantMerchant
 		public static implicit operator PantMerchant.Point2D(SwinGameSDK.Point2D p){
             // Automatically convert between my Point2D and SwinGame's Point2D
             PantMerchant.Point2D result = new PantMerchant.Point2D ();
-			result.X = p.X;
-			result.Y = p.Y;
+			result.X = Point2D.Round(p.X);
+			result.Y = Point2D.Round(p.Y);
 			return result;
 		}
+
+        /// <summary>
+        /// Rounds a double to the nearest int
+        /// </summary>
+        /// <param name="d"></param>
+        /// <returns></returns>
+        private static int Round(double d)
+        {
+            if (d < 0)
+            {
+                return (int)(d - 0.5);
+            }
+            return (int)(d + 0.5);
+        }
 	}
 }
 


### PR DESCRIPTION
Changing the Point2D class to use integers instead of floating points makes sense because the grid system will require coordinates to be whole numbers. There will be no occupiable position between grids.
