### PR TITLE
Change point2D back to float types

### DIFF
--- a/PantMerchant.xml
+++ b/PantMerchant.xml
@@ -1,0 +1,835 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>PantMerchant</name>
+    </assembly>
+    <members>
+        <member name="T:PantMerchant.Controller">
+            <summary>
+            Base controller class. 
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Controller.UIElementList">
+            <summary>
+            List of all UI elements instantiated. Added to whichever 
+            controller is currently in charge
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Controller.IClickableList">
+            <summary>
+            List of all IClickables instantiated. Added to whichever 
+            controller is currently in charge
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Controller.IDrawableList">
+            <summary>
+            List of all IDrawables instantiated. Added to whichever 
+            controller is currently in charge
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Controller.Instance">
+            <summary>
+            The singleton instance of the current controller.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Controller.#ctor">
+            <summary>
+            Initialises the base Controller class.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Controller.DoClickActions">
+            <summary>
+            Handles click actions for all IClickables being 
+            managed by the current controller
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Controller.DoControllerStuff">
+            <summary>
+            Overridden by child class. Allows controller actions to be 
+            performed regardless of which controller is currently in 
+            control.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.GameController">
+            <summary>
+            Controller handling actions when in-game.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GameController.Instance">
+            <summary>
+            The singleton instance of the current controller.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GameController.Test">
+            <summary>
+            Test person
+            </summary>
+        </member>
+        <member name="M:PantMerchant.GameController.#cctor">
+            <summary>
+            Static constructor for the current controller
+            </summary>
+        </member>
+        <member name="M:PantMerchant.GameController.DoControllerStuff">
+            <summary>
+            Handles click actions for all IClickables being 
+            managed by the current controller, as well as 
+            drawing all IDrawables to the screen.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.MainMenuController">
+            <summary>
+            Controller handling actions when the main-menu is open.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.MainMenuController.Instance">
+            <summary>
+            The singleton instance of the current controller.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.MainMenuController.#cctor">
+            <summary>
+            Static constructor for the current controller
+            </summary>
+        </member>
+        <member name="P:PantMerchant.MainMenuController.MainMenu">
+            <summary>
+            The main menu to draw.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.MainMenuController.DoControllerStuff">
+            <summary>
+            Handles click actions for all IClickables being 
+            managed by the current controller, as well as 
+            drawing all IDrawables to the screen.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.MainMenuController.BuildMainMenu">
+            <summary>
+            Initialises the main menu.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.StateController">
+            <summary>
+            This class can be thought of as the Controller controller.
+            The game's "state" determines which controller is in control
+            of the input at a given time. The state controller keeps 
+            track of whether you are on the main menu, in the middle of 
+            the game, or about to quit.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.StateController.UIElementList">
+            <summary>
+            List of all UI elements instantiated. Added to whichever 
+            controller is currently in charge
+            </summary>
+        </member>
+        <member name="P:PantMerchant.StateController.IClickableList">
+            <summary>
+            List of all IClickables instantiated. Added to whichever 
+            controller is currently in charge
+            </summary>
+        </member>
+        <member name="P:PantMerchant.StateController.IDrawableList">
+            <summary>
+            List of all IDrawables instantiated. Added to whichever 
+            controller is currently in charge
+            </summary>
+        </member>
+        <member name="P:PantMerchant.StateController.Instance">
+            <summary>
+            The singleton instance of the current controller.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.StateController.CurrentState">
+            <summary>
+            The state the game is currently in
+            </summary>
+        </member>
+        <member name="P:PantMerchant.StateController.CurrentController">
+            <summary>
+            The controller which is currently in charge.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.#cctor">
+            <summary>
+            Static constructor for the current controller
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.StartGame">
+            <summary>
+            Changes the game state to InGame, and putting the 
+            GameController in charge
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.PauseGame">
+            <summary>
+            Pauses the game if in game.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.QuitToMainMenu">
+            <summary>
+            Changes the game state to MainMenu, switching out to the main menu.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.QuitToDesktop">
+            <summary>
+            Changes the game state to UserQuit, quitting the program.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.DoControllerStuff">
+            <summary>
+            Calls the DoControllerStuff method on the current controller
+            </summary>
+        </member>
+        <member name="M:PantMerchant.StateController.DoCurrentControllerStuff">
+            <summary>
+            Calls the DoControllerStuff method on the current controller
+            </summary>
+        </member>
+        <member name="T:PantMerchant.GameState">
+            <summary>
+            Enumeration defining different program states
+            </summary>
+        </member>
+        <member name="F:PantMerchant.GameState.MainMenu">
+            <summary>
+            Main Menu
+            </summary>
+        </member>
+        <member name="F:PantMerchant.GameState.InGame">
+            <summary>
+            In Game
+            </summary>
+        </member>
+        <member name="F:PantMerchant.GameState.GamePause">
+            <summary>
+            Paused Game - show the pause menu
+            </summary>
+        </member>
+        <member name="F:PantMerchant.GameState.UserQuit">
+            <summary>
+            User has quit the game
+            </summary>
+        </member>
+        <member name="T:PantMerchant.BaseEntity">
+            <summary>
+            Abstract base class to be used by all grid entities.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.ResourcePath">
+            <summary>
+            The path containing the entity resources
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.Image">
+            <summary>
+            Returns the appropriate image based on the direction the entity is facing.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.Grid">
+            <summary>
+            Returns a reference to the grid containing this entity.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.ScreenPos">
+            <summary>
+            The on-screen coordinates of the entity
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.Position">
+            <summary>
+            The position on the grid.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.Facing">
+            <summary>
+            The direction the entity is facing.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.BaseEntity.Footprint">
+            <summary>
+            A list of grid points relative to the
+            position that the entity will take up.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.BaseEntity.#ctor(PantMerchant.Point2D,System.Collections.Generic.List{PantMerchant.Point2D})">
+            <summary>
+            Initialises a new instance of BaseEntity with the 
+            given position and footprint.
+            </summary>
+            <param name="position">The position of the entity on the grid</param>
+            <param name="footprint">The footprint of the </param>
+        </member>
+        <member name="M:PantMerchant.BaseEntity.#ctor(PantMerchant.Point2D,System.Collections.Generic.List{PantMerchant.Point2D},System.String)">
+            <summary>
+            Initialises a new instance of BaseEntity with the 
+            given position, footprint, and resource path.
+            </summary>
+            <param name="position">The position of the entity on the grid</param>
+            <param name="footprint">The footprint of the entity</param>
+            <param name="resourcePath">The path containing the entity resources</param>
+        </member>
+        <member name="M:PantMerchant.BaseEntity.Draw">
+            <summary>
+            Used by the View class to draw IDrawable objects to the screen.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.Customer">
+            <summary>
+            Concrete customer class
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Customer.#ctor(System.String,PantMerchant.Point2D)">
+            <summary>
+            Initialises a new instance of Person with 
+            the given name at the given position.
+            </summary>
+            <param name="Name">Name of the person. eg "John Smith"</param>
+            <param name="position">Grid position the person currently occupies</param>
+        </member>
+        <member name="T:PantMerchant.GridCell">
+            <summary>
+            Basic in-game positional unit. Manages the entity 
+            which in contains, as well as references to it's
+            neighbours.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.Entity">
+            <summary>
+            The entity which occupies this GridCell
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.Image">
+            <summary>
+            Image to draw to the screen
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.ScreenPos">
+            <summary>
+            On-screen position of the GridCell.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.Pos">
+            <summary>
+            Position of the GridCell
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.GridSize">
+            <summary>
+            Size of the grids on the screen (in pixels)
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.NeighbourTop">
+            <summary>
+            The GridCell to the top (top-right) of this one.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.NeighbourRight">
+            <summary>
+            The GridCell to the right (bottom-right) of this one.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.NeighbourBottom">
+            <summary>
+            The GridCell to the bottom (bottom-left) of this one.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.NeighbourLeft">
+            <summary>
+            The GridCell to the left (top-left) of this one.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.GridCell.Origin">
+            <summary>
+            Grid cell at the position (0, 0)
+            </summary>
+        </member>
+        <member name="M:PantMerchant.GridCell.#cctor">
+            <summary>
+            Static constructor for GridCell type
+            </summary>
+        </member>
+        <member name="M:PantMerchant.GridCell.#ctor(PantMerchant.Point2D)">
+            <summary>
+            Initialises a new GridCell instance
+            with the position set to p
+            </summary>
+            <param name="p">The position of the Gridcell</param>
+        </member>
+        <member name="M:PantMerchant.GridCell.GetGrid(PantMerchant.Point2D)">
+            <summary>
+            Retrieves the GridCell with the specified position
+            </summary>
+            <param name="p">The position of the GridCell you'd like</param>
+            <returns>A GridCell with the specified position</returns>
+        </member>
+        <member name="M:PantMerchant.GridCell.Draw">
+            <summary>
+            Highlights the GridCell by drawing a black line around the edges.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.GridOccupiedExcepion">
+            <summary>
+            Thrown when an entity tries to occupy a GridCell which already contains another entity.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.GridOccupiedExcepion.#ctor">
+            <summary>
+            Initialises a new instance of GridOccupiedException.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.GridOccupiedExcepion.#ctor(System.String)">
+            <summary>
+            Initialises a new instance of GridOccupiedException with the given message.
+            </summary>
+            <param name="message">Message explaining the exception.</param>
+        </member>
+        <member name="M:PantMerchant.IMovable.Move(PantMerchant.Direction)">
+            <summary>
+            Used to move the IMovable one grid in the 
+            given direction
+            </summary>
+            <param name="d">The direction to move the IMovable</param>
+        </member>
+        <member name="T:PantMerchant.Direction">
+            <summary>
+            Enumeration specifying valid directions for the 
+            Move() method of IMovable
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Direction.None">
+            <summary>
+            No direction. Used as the default value when a direction is instantiated.
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Direction.Up">
+            <summary>
+            Up direction. Corresponds to top-right on the grid.
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Direction.Right">
+            <summary>
+            Right direcetion. Corresponds to bottom-right on the grid.
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Direction.Down">
+            <summary>
+            Down direction. Corresponds to bottom-left on the grid.
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Direction.Left">
+            <summary>
+            Left direction. Corresponds to top-left on the grid.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.Person">
+            <summary>
+            Abstract base class used by all human entities
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Person.Name">
+            <summary>
+            Name of the person. "John Smith", etc.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Person.#ctor(System.String,PantMerchant.Point2D,System.String)">
+            <summary>
+            Initialises a new instance of Person with 
+            the given name at the given position.
+            </summary>
+            <param name="name">Name of the person. eg "John Smith"</param>
+            <param name="position">Grid position the person currently occupies</param>
+            <param name="resourcePath">The path containing the entity resources</param>
+        </member>
+        <member name="M:PantMerchant.Person.Move(PantMerchant.Direction)">
+            <summary>
+            Used to move the Person one grid in the given direction
+            </summary>
+            <param name="d">The direction to move the Person</param>
+        </member>
+        <member name="M:PantMerchant.Person.Draw">
+            <summary>
+            Used by the View class to draw the Person to the screen.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.Point2D">
+            <summary>
+            Basic vector class. Based on SwinGame's Point2D 
+            class, but with some helpful overloads
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Point2D.X">
+            <summary>
+            Vector components
+            </summary>
+        </member>
+        <member name="F:PantMerchant.Point2D.Y">
+            <summary>
+            Vector components
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Point2D.Origin">
+            <summary>
+            A Point2D with components (0, 0)
+            </summary>
+        </member>
+        <member name="P:PantMerchant.Point2D.ScreenMiddle">
+            <summary>
+            A Point2D which represents the middle of the game window (in pixels).
+            </summary>
+            <remarks>This property is lazily evaluated, as it needs to be reflective of screen-size changes.</remarks>
+        </member>
+        <member name="M:PantMerchant.Point2D.#ctor">
+            <summary>
+            Initialises a new Point2D instance with X and Y set to zero.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.Point2D.#ctor(System.Single,System.Single)">
+            <summary>
+            Initialises a new Poin2D instance with X and Y set.
+            </summary>
+            <param name="X">Value to set X component to</param>
+            <param name="Y">Value to set Y component to</param>
+        </member>
+        <member name="M:PantMerchant.Point2D.ToString">
+            <summary>
+            Enables printing the class.
+            </summary>
+            <returns>[X,Y]</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.GetRelativePosition(PantMerchant.Point2D)">
+            <summary>
+            Returns the displacement of the provided Point2D from the 
+            current one. How many X units and how many Y units to travel 
+            to go from this one to the provided one.
+            </summary>
+            <param name="p">Point2D to compare with this one.</param>
+            <returns>Point2D representing the displacement between the provided one and the current one.</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Equality(PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Determines if the coordinates are equal. Returns true if X and Y components are respectively equal.
+            </summary>
+            <param name="p1">First Point2D</param>
+            <param name="p2">Second Point2D</param>
+            <returns>True if Point2Ds refer to the same coordinate</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Inequality(PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Determines if the coordinates are not equal. Returns true if X and Y components are respectively not equal.
+            </summary>
+            <param name="p1">First Point2D</param>
+            <param name="p2">Second Point2D</param>
+            <returns>False if Point2Ds refer to the same coordinate</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.Equals(System.Object)">
+            <summary>
+            Determines if the object is equal to the current Point2D. Returns true if obj is a Point2D and X and Y components are respectively equal.
+            </summary>
+            <param name="obj">Object to compare</param>
+            <returns>True if obj is a Point2D and refers to the same coordinate as current Point2D</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.GetHashCode">
+            <summary>
+            Gets hash code based on the sum of the X and Y coordinates.
+            </summary>
+            <returns>Hash code based on sum of components</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Addition(PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Performs vector addition on two Point2Ds
+            </summary>
+            <param name="p1">Point2D to sum</param>
+            <param name="p2">Point2D to sum</param>
+            <returns>Returns the vector sum of p1 and p2</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Subtraction(PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Performs vector subtraction on two Point2Ds
+            </summary>
+            <param name="p1">Point2D to perform subtraction on</param>
+            <param name="p2">Point2D to subtract from p1</param>
+            <returns>Returns the vector sum of p1 and -(p2)</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Multiply(PantMerchant.Point2D,System.Single)">
+            <summary>
+            Performs scalar multiplication on a vector p with d
+            </summary>
+            <param name="p">The vector to multiply</param>
+            <param name="d">The scalar to multiply the p by</param>
+            <returns>The product of p and d</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Division(PantMerchant.Point2D,System.Single)">
+            <summary>
+            Performs scalar division on a vector p with i, 
+            rounding the components of p to the nearest integer.
+            Equivalent to multiplying p by the reciprocal of i
+            </summary>
+            <param name="p">The vector to perform the division on</param>
+            <param name="d">The scalar to divide p by</param>
+            <returns>The quotient of p by d</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Implicit(PantMerchant.Point2D)~SwinGameSDK.Point2D">
+            <summary>
+            Performs implicit conversion between PantMerchant's Point2D and 
+            SwinGame's in-built Point2D class.
+            </summary>
+            <param name="p">PantMerchant Point2D to convert</param>
+            <returns>SwinGame Point2D</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.op_Implicit(SwinGameSDK.Point2D)~PantMerchant.Point2D">
+            <summary>
+            Performs implicit conversion between PantMerchant's Point2D and 
+            SwinGame's in-built Point2D class.
+            </summary>
+            <param name="p">SwinGame Point2D to convert</param>
+            <returns>PantMerchant Point2D</returns>
+        </member>
+        <member name="M:PantMerchant.Point2D.Round(System.Double)">
+            <summary>
+            Rounds a double to the nearest int
+            </summary>
+            <param name="d"></param>
+            <returns></returns>
+        </member>
+        <member name="T:PantMerchant.PantMerchantMain">
+            <summary>
+            Main class
+            </summary>
+        </member>
+        <member name="M:PantMerchant.PantMerchantMain.EndProgramRequested">
+            <summary>
+             Method which encapsulates requests to end the 
+             program in one place.
+            </summary>
+            <returns>Boolean indicating whether the user has requested to close the program.</returns>
+        </member>
+        <member name="M:PantMerchant.PantMerchantMain.Main">
+            <summary>
+            Program entry point
+            </summary>
+        </member>
+        <member name="T:PantMerchant.IClickable">
+            <summary>
+            Interface used by clickable objects.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.IClickable.ClickAction">
+            <summary>
+            Action performed when the implementing object has been "clicked" on.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.IClickable.IsClicked">
+            <summary>
+            Method to determine whether the object has been clicked on or not.
+            </summary>
+            <returns>True if object has been clicked, false if object has not been clicked.</returns>
+        </member>
+        <member name="T:PantMerchant.MenuElement">
+            <summary>
+            This class is used to create dynamic menus, from the main menu, to in-game context menus.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.MenuElement.Text">
+            <summary>
+            Text displayed on the menu button
+            </summary>
+        </member>
+        <member name="T:PantMerchant.UIContainer">
+            <summary>
+            UIElement which is able to contain other UIElements. 
+            Used to create dropdown menus, etc.
+            </summary>
+        </member>
+        <member name="F:PantMerchant.UIContainer.Type">
+            <summary>
+            Specifies how the ChildElements are drawn to the screen. If Auto, ChildElements 
+            are drawn at automatic positions, filling up the whole x-axis and evenly split
+            down the y axis.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIContainer.ChildElements">
+            <summary>
+            List containing the UI elements which 
+            are contained by this UI container.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIContainer.GameWindow">
+            <summary>
+            Static UI container used for placing UI 
+            elements within the "root" container, 
+            the game window.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.UIContainer.#cctor">
+            <summary>
+            Initialises the static members of UIContainer.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.UIContainer.#ctor(System.String,PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Initialises a new instance of UIContainer with the given name, position and size.
+            </summary>
+            <param name="Name">The name of the UI container</param>
+            <param name="Pos">The position of the UI container</param>
+            <param name="Size">The size of the UI container</param>
+        </member>
+        <member name="M:PantMerchant.UIContainer.#ctor(System.String,PantMerchant.Point2D,PantMerchant.Point2D,PantMerchant.MenuType)">
+            <summary>
+            Initialises a new instance of UIContainer with the given name, position, size and type option.
+            </summary>
+            <param name="Name">The name of the UI container</param>
+            <param name="Pos">The position of the UI container</param>
+            <param name="Size">The size of the UI container</param>
+            <param name="Type">Specifies whether the elements inside are automatically placed when draw, or if their position is manually specified.</param>
+        </member>
+        <member name="M:PantMerchant.UIContainer.#ctor(System.Collections.Generic.List{PantMerchant.UIElement},System.String,PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Initialises a new instance of UIContainer with the given name, position and size, and containing the specified UIElements
+            </summary>
+            <param name="ChildElements">List of UIElements this UIContainer contains</param>
+            <param name="Name">The name of the UI container</param>
+            <param name="Pos">The position of the UI container</param>
+            <param name="Size">The size of the UI container</param>
+        </member>
+        <member name="M:PantMerchant.UIContainer.#ctor(System.Collections.Generic.List{PantMerchant.UIElement},System.String,PantMerchant.Point2D,PantMerchant.Point2D,PantMerchant.MenuType)">
+            <summary>
+            Initialises a new instance of UIContainer with the given name, position, size and type options, and containing the specified UIElements
+            </summary>
+            <param name="ChildElements">List of UIElements this UIContainer contains</param>
+            <param name="Name">The name of the UI container</param>
+            <param name="Pos">The position of the UI container</param>
+            <param name="Size">The size of the UI container</param>
+            <param name="Type">Specifies whether the elements inside are automatically placed when draw, or if their position is manually specified.</param>
+        </member>
+        <member name="M:PantMerchant.UIContainer.Draw">
+            <summary>
+            Draws the UIContainer to the screen.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.MenuType">
+            <summary>
+            Enum defining whether the menu elements are placed manually or automatically within the UI container
+            </summary>
+        </member>
+        <member name="F:PantMerchant.MenuType.Auto">
+            <summary>
+            Menu elements are placed automatically, filling the container.
+            </summary>
+        </member>
+        <member name="F:PantMerchant.MenuType.Manual">
+            <summary>
+            Menu elements are placed manually, allowing the position and size within the UI container to be specified.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.UIElement">
+            <summary>
+            Base class for any element of the UI. All buttons in 
+            all menus, HUD displays, etc. Anything from a "New 
+            Game" button on the main menu to an in-game minimap, 
+            to a dropdown context menu should inherit from this 
+            class. Can also act as a container for other UI 
+            Elements.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.Name">
+            <summary>
+            Internal name given to the UI element. 
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.ScreenPos">
+            <summary>
+            The on-screen coordinates of the UI element
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.Pos">
+            <summary>
+            The position of the UI element. These coordinates 
+            are on screen. Where the UI element is a part of 
+            a UI container, the position is relative to the 
+            position of the container, otherwise is relative 
+            to the program window.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.Size">
+            <summary>
+            The width and height of the UI element. Each 
+            component of the Point2D refers to the distance 
+            of that point from it's corresponding component 
+            in the Pos property.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.ScreenSize">
+            <summary>
+            The on-screen size of the UI element. Used when
+            the container type is auto.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.Container">
+            <summary>
+            The container of the UI element. For when UI 
+            elements need to exist within context menus, 
+            popup menus, etc.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.UIElement.Image">
+            <summary>
+            Image to draw to screen
+            </summary>
+        </member>
+        <member name="M:PantMerchant.UIElement.#ctor(System.String,PantMerchant.Point2D,PantMerchant.Point2D)">
+            <summary>
+            Initialises a new instance of the UIElement class with the given name, position and size.
+            </summary>
+            <param name="Name">Name given to the UI element</param>
+            <param name="Pos">Position of the UI element</param>
+            <param name="Size">Size of the UI element</param>
+        </member>
+        <member name="M:PantMerchant.UIElement.#ctor(System.String,PantMerchant.Point2D,PantMerchant.Point2D,PantMerchant.UIContainer)">
+            <summary>
+            Initialises a new instance of the UIElement class with the given name, position and size, within the given UIContainer.
+            </summary>
+            <param name="Name">Name given to the UI element</param>
+            <param name="Pos">Position of the UI element</param>
+            <param name="Size">Size of the UI element</param>
+            <param name="Container">UIContainer containing the new UIElement</param>
+        </member>
+        <member name="M:PantMerchant.UIElement.Draw">
+            <summary>
+            Used by the View class to draw IDrawable objects to the screen.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.IDrawable">
+            <summary>
+            Interface used by view class to draw entities to the screen.
+            </summary>
+        </member>
+        <member name="P:PantMerchant.IDrawable.ScreenPos">
+            <summary>
+            Position on the screen to draw the object
+            </summary>
+        </member>
+        <member name="P:PantMerchant.IDrawable.Image">
+            <summary>
+            Image to draw to the screen.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.IDrawable.Draw">
+            <summary>
+            Draws the entity to the screen.
+            </summary>
+        </member>
+        <member name="T:PantMerchant.View">
+            <summary>
+            Global class used to manage drawing to 
+            the screen.
+            </summary>
+        </member>
+        <member name="M:PantMerchant.View.Draw">
+            <summary>
+            Used to draw all IDrawable objects to the screen.
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/src/Entities/GridCell.cs
+++ b/src/Entities/GridCell.cs
@@ -175,6 +175,7 @@ namespace PantMerchant
 
         public GridCell(Point2D p, string resourcePath)
         {
+            p.Round();
             this.Pos = p;
             StateController.Instance.CurrentController.IDrawableList.Add(this);
 
@@ -195,12 +196,14 @@ namespace PantMerchant
         /// <returns>A GridCell with the specified position</returns>
         public static GridCell GetGrid(Point2D p)
         {
+            p.Round();
+
             if (p == Point2D.Origin)
             {
                 return GridCell.Origin;
             }
 
-            return _grid[50 + p.X, 50 + p.Y];
+            return _grid[50 + (int)p.X, 50 + (int)p.Y];
         }
 
         /// <summary>

--- a/src/Entities/Point2D.cs
+++ b/src/Entities/Point2D.cs
@@ -14,7 +14,7 @@ namespace PantMerchant
         /// <summary>
         /// Vector components
         /// </summary>
-		public int X, Y;
+		public float X, Y;
 
         /// <summary>
         /// A Point2D with components (0, 0)
@@ -51,7 +51,7 @@ namespace PantMerchant
         /// </summary>
         /// <param name="X">Value to set X component to</param>
         /// <param name="Y">Value to set Y component to</param>
-		public Point2D(int X, int Y) {
+		public Point2D(float X, float Y) {
 			this.X = X;
 			this.Y = Y;
 		}
@@ -150,8 +150,8 @@ namespace PantMerchant
         /// <param name="p">The vector to multiply</param>
         /// <param name="d">The scalar to multiply the p by</param>
         /// <returns>The product of p and d</returns>
-		public static Point2D operator *(Point2D p, double d) {
-			return new Point2D(Point2D.Round(p.X * d), Point2D.Round(p.Y * d));
+		public static Point2D operator *(Point2D p, float d) {
+			return new Point2D(p.X * d, p.Y * d);
 		}
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace PantMerchant
         /// <param name="p">The vector to perform the division on</param>
         /// <param name="d">The scalar to divide p by</param>
         /// <returns>The quotient of p by d</returns>
-		public static Point2D operator /(Point2D p, double d) {
+		public static Point2D operator /(Point2D p, float d) {
             return p * (1 / d);
 		}
         
@@ -191,13 +191,19 @@ namespace PantMerchant
         /// </summary>
         /// <param name="d"></param>
         /// <returns></returns>
-        private static int Round(double d)
+        public static int Round(double d)
         {
             if (d < 0)
             {
                 return (int)(d - 0.5);
             }
             return (int)(d + 0.5);
+        }
+
+        public void Round()
+        {
+            this.X = Point2D.Round(this.X);
+            this.Y = Point2D.Round(this.Y);
         }
 	}
 }


### PR DESCRIPTION
This change came about due to getting rounding errors when trying to divide point2ds with odd numbers (they would round up), resulting in failed tests. Point2Ds are now not exclusively used for grid positions, but are used for screen coordinates, etc. Float is a more appropriate type.
